### PR TITLE
Feature/improve undelegate logic

### DIFF
--- a/client/src/components/Common/Layout/Stake/Table.jsx
+++ b/client/src/components/Common/Layout/Stake/Table.jsx
@@ -11,7 +11,7 @@ const StakingAccountListComponent = ({
 	isLoading = false,
 	isConfirmingTrans,
 }) => {
-	if (!stakingDeployList.length) {
+	if (!stakingDeployList.length || isLoading) {
 		return <EmptyDelegation isLoading={isLoading} />;
 	}
 

--- a/client/src/components/Common/Layout/Stake/Table.jsx
+++ b/client/src/components/Common/Layout/Stake/Table.jsx
@@ -49,7 +49,10 @@ const StakingAccountListComponent = ({
 								<TableActions
 									validator={staking}
 									unDelegateFunc={unDelegateFunc}
-									disableAction={pendingStakes.find((item) => staking.validator === item.validator)}
+									disableAction={
+										Array.isArray(pendingStakes) &&
+										pendingStakes.find((item) => staking.validator === item.validator)
+									}
 								/>
 							</td>
 						</tr>

--- a/client/src/components/Common/Layout/Stake/Table.jsx
+++ b/client/src/components/Common/Layout/Stake/Table.jsx
@@ -5,7 +5,12 @@ import CommonAction from '../../Button/CommonAction';
 import EmptyDelegation from './EmptyDelegation';
 import TableActions from './TableActions';
 
-const StakingAccountListComponent = ({ stakingDeployList = [], unDelegateFunc, isLoading = false }) => {
+const StakingAccountListComponent = ({
+	stakingDeployList = [],
+	unDelegateFunc,
+	isLoading = false,
+	pendingStakes = [],
+}) => {
 	if (!stakingDeployList.length || isLoading) {
 		return <EmptyDelegation isLoading={isLoading} />;
 	}
@@ -41,7 +46,11 @@ const StakingAccountListComponent = ({ stakingDeployList = [], unDelegateFunc, i
 								{displayNaN(toFormattedNumber(staking.stakedAmount))}
 							</td>
 							<td className="cd_stake_table_actions">
-								<TableActions validator={staking} unDelegateFunc={unDelegateFunc} />
+								<TableActions
+									validator={staking}
+									unDelegateFunc={unDelegateFunc}
+									disableAction={pendingStakes.find((item) => staking.validator === item.validator)}
+								/>
 							</td>
 						</tr>
 					))}

--- a/client/src/components/Common/Layout/Stake/Table.jsx
+++ b/client/src/components/Common/Layout/Stake/Table.jsx
@@ -5,12 +5,7 @@ import CommonAction from '../../Button/CommonAction';
 import EmptyDelegation from './EmptyDelegation';
 import TableActions from './TableActions';
 
-const StakingAccountListComponent = ({
-	stakingDeployList = [],
-	unDelegateFunc,
-	isLoading = false,
-	isConfirmingTrans,
-}) => {
+const StakingAccountListComponent = ({ stakingDeployList = [], unDelegateFunc, isLoading = false }) => {
 	if (!stakingDeployList.length || isLoading) {
 		return <EmptyDelegation isLoading={isLoading} />;
 	}
@@ -46,11 +41,7 @@ const StakingAccountListComponent = ({
 								{displayNaN(toFormattedNumber(staking.stakedAmount))}
 							</td>
 							<td className="cd_stake_table_actions">
-								<TableActions
-									validator={staking}
-									unDelegateFunc={unDelegateFunc}
-									disableAction={isConfirmingTrans}
-								/>
+								<TableActions validator={staking} unDelegateFunc={unDelegateFunc} />
 							</td>
 						</tr>
 					))}

--- a/client/src/components/Common/Layout/Stake/Table.test.jsx
+++ b/client/src/components/Common/Layout/Stake/Table.test.jsx
@@ -25,3 +25,8 @@ test('Should display empty list', async () => {
 		)[0].textContent,
 	).toBe('You do not have any delegations yet. Stake CSPR, earn rewards and help Casper become more secure!');
 });
+
+test('Should display empty list if loading validators', async () => {
+	const { queryAllByText } = render(<Table isLoading={true} />);
+	expect(queryAllByText('Loading validators')[0].textContent).toBe('Loading validators');
+});

--- a/client/src/components/Stake/index.jsx
+++ b/client/src/components/Stake/index.jsx
@@ -101,7 +101,6 @@ const Stake = () => {
 					<StakingAccountList
 						stakingDeployList={stakingDeployList}
 						isLoading={isLoading}
-						isConfirmingTrans={isConfirmingTrans}
 						unDelegateFunc={(validator) => undelegate(validator)}
 					/>
 				</div>

--- a/client/src/components/Stake/index.jsx
+++ b/client/src/components/Stake/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import HeadingModule from '../Common/Layout/HeadingComponent/Heading';
 import StakingAccountList from '../Common/Layout/Stake/Table';
@@ -12,6 +12,7 @@ import { useStakeFromValidators } from '../hooks/useStakeDeploys';
 import ConfirmingTransactionsInfo from '../Common/Layout/Stake/ConfirmingTransactionsInfo';
 import UnlockSingerWarning from '../Common/Layout/Stake/UnlockSingerWarning';
 import StakeForm from '../Common/Layout/Stake/Form';
+import { useAutoRefreshEffect } from '../hooks/useAutoRefreshEffect';
 import StakeButton from './Button';
 
 const Stake = () => {
@@ -31,9 +32,12 @@ const Stake = () => {
 	const pendingStakes = useSelector(getPendingStakes());
 	const stakingDeployList = useStakeFromValidators(publicKey);
 
-	useEffect(() => {
-		dispatch(fetchValidators());
-	}, [dispatch]);
+	useAutoRefreshEffect(() => {
+		// Prevent the duplicated fetching
+		if (isLoading) {
+			dispatch(fetchValidators());
+		}
+	}, [dispatch, isLoading]);
 
 	// Function
 	const handleToggle = () => {

--- a/client/src/components/Stake/index.jsx
+++ b/client/src/components/Stake/index.jsx
@@ -5,11 +5,10 @@ import StakingAccountList from '../Common/Layout/Stake/Table';
 import { MessageModal } from '../Common/Layout/Modal/MessageModal';
 import { getMassagedUserDetails, getPublicKey } from '../../selectors/user';
 import { getCurrentPrice } from '../../selectors/price';
-import { getValidators } from '../../selectors/validator';
+import { getValidators, validatorSelector } from '../../selectors/validator';
 import { fetchValidators } from '../../actions/stakeActions';
 import { getPendingStakes } from '../../selectors/stake';
 import { useStakeFromValidators } from '../hooks/useStakeDeploys';
-import { isLoadingRequest } from '../../selectors/request';
 import ConfirmingTransactionsInfo from '../Common/Layout/Stake/ConfirmingTransactionsInfo';
 import UnlockSingerWarning from '../Common/Layout/Stake/UnlockSingerWarning';
 import StakeForm from '../Common/Layout/Stake/Form';
@@ -27,9 +26,7 @@ const Stake = () => {
 	const publicKey = useSelector(getPublicKey);
 	const currentPrice = useSelector(getCurrentPrice);
 	const validators = useSelector(getValidators);
-	// Selector
-	const isLoading = useSelector(isLoadingRequest);
-
+	const { loading: isLoading } = useSelector(validatorSelector);
 	const userDetails = useSelector(getMassagedUserDetails);
 	const pendingStakes = useSelector(getPendingStakes());
 	const stakingDeployList = useStakeFromValidators(publicKey);

--- a/client/src/components/Stake/index.jsx
+++ b/client/src/components/Stake/index.jsx
@@ -102,6 +102,7 @@ const Stake = () => {
 						stakingDeployList={stakingDeployList}
 						isLoading={isLoading}
 						unDelegateFunc={(validator) => undelegate(validator)}
+						pendingStakes={pendingStakes}
 					/>
 				</div>
 				<MessageModal

--- a/client/src/components/Stake/index.test.jsx
+++ b/client/src/components/Stake/index.test.jsx
@@ -91,7 +91,7 @@ test('Have delegations', () => {
 describe('Trigger stake form', () => {
 	test('Can show stake form', async () => {
 		spyOnUseSelector
-			.mockReturnValue(0x123)
+			.mockReturnValue([])
 			.mockReturnValueOnce({})
 			.mockReturnValueOnce([])
 			.mockReturnValueOnce([
@@ -115,7 +115,14 @@ describe('Trigger stake form', () => {
 
 	test('Can trigger undelegate', async () => {
 		spyOnUseSelector
-			.mockReturnValue('0x125')
+			.mockReturnValue([
+				{
+					validator: '0x111',
+				},
+				{
+					validator: '0x112',
+				},
+			])
 			.mockReturnValueOnce('0x124')
 			.mockReturnValueOnce([])
 			.mockReturnValueOnce([
@@ -137,7 +144,14 @@ describe('Trigger stake form', () => {
 
 	test('Can trigger undelegate when do not have validators', async () => {
 		spyOnUseSelector
-			.mockReturnValue('0x125')
+			.mockReturnValue([
+				{
+					validator: '0x111',
+				},
+				{
+					validator: '0x112',
+				},
+			])
 			.mockReturnValueOnce('0x124')
 			.mockReturnValueOnce([])
 			.mockReturnValueOnce([]);
@@ -155,7 +169,11 @@ describe('Trigger stake form', () => {
 
 	test('Can trigger toggle', async () => {
 		spyOnUseSelector
-			.mockReturnValue('0x125')
+			.mockReturnValue([
+				{
+					validator: '0x125',
+				},
+			])
 			.mockReturnValueOnce('0x124')
 			.mockReturnValueOnce([])
 			.mockReturnValueOnce([]);
@@ -174,7 +192,11 @@ describe('Trigger stake form', () => {
 
 	test('Can trigger undelegate toggle', async () => {
 		spyOnUseSelector
-			.mockReturnValue('0x125')
+			.mockReturnValue([
+				{
+					validator: '0x125',
+				},
+			])
 			.mockReturnValueOnce(['0x124'])
 			.mockReturnValueOnce([])
 			.mockReturnValueOnce([]);

--- a/client/src/components/hooks/useStakeDeploys.js
+++ b/client/src/components/hooks/useStakeDeploys.js
@@ -5,7 +5,7 @@ import { getPendingStakes } from '../../selectors/stake';
 import { getValidators } from '../../selectors/validator';
 import { getTransferDeploysStatus } from '../../actions/deployActions';
 import { ENTRY_POINT_UNDELEGATE } from '../../constants/key';
-import { getStakeFromLocalStorage, updateStakeDeployStatus } from '../../actions/stakeActions';
+import { fetchValidators, getStakeFromLocalStorage, updateStakeDeployStatus } from '../../actions/stakeActions';
 import { useAutoRefreshEffect } from './useAutoRefreshEffect';
 
 /**
@@ -64,7 +64,6 @@ export const useStakeFromValidators = (publicKey) => {
 
 	const validators = useSelector(getValidators);
 	const pendingStakes = useSelector(getPendingStakes());
-
 	useEffect(() => {
 		dispatch(getStakeFromLocalStorage(publicKey));
 	}, [dispatch, publicKey]);
@@ -76,7 +75,10 @@ export const useStakeFromValidators = (publicKey) => {
 		(async () => {
 			if (!publicKey) return;
 			const { data } = await dispatch(getTransferDeploysStatus(pendingStakes.map((stake) => stake.deployHash)));
-			dispatch(updateStakeDeployStatus(publicKey, 'deploys.stakes', data));
+			if (data && data.some((item) => 'success' === item.status)) {
+				dispatch(fetchValidators());
+				dispatch(updateStakeDeployStatus(publicKey, 'deploys.stakes', data));
+			}
 		})();
 	}, [JSON.stringify(pendingStakes), dispatch]);
 

--- a/client/src/components/hooks/useStakeDeploys.js
+++ b/client/src/components/hooks/useStakeDeploys.js
@@ -75,7 +75,7 @@ export const useStakeFromValidators = (publicKey) => {
 		(async () => {
 			if (!publicKey) return;
 			const { data } = await dispatch(getTransferDeploysStatus(pendingStakes.map((stake) => stake.deployHash)));
-			if (data && data.some((item) => 'success' === item.status)) {
+			if (data && data.some((item) => 'pending' !== item.status)) {
 				dispatch(fetchValidators());
 				dispatch(updateStakeDeployStatus(publicKey, 'deploys.stakes', data));
 			}


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)

- Fix issue that the validators have never reloaded
- Only disable the undelegate button for record having pending transaction

### Checklist (If you won't pass this checklist please comment why)

-   [x] I removed all commented or unnecessary code.
-   [ ] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):

- Delegate => can update the delegations table after having success deploy
- Undelegate => can update the delegations table after having success deploy
- Can do multiple undelegations
