### PR TITLE
Guard deploy hash property and remove UT failed ignore

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -36,7 +36,6 @@ jobs:
     
     - name: Run UT
       working-directory: /client
-      continue-on-error: true
       run : |
           yarn
           yarn run test-ci

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -35,7 +35,6 @@ jobs:
 
             - name: Run UT
               working-directory: ./client
-              continue-on-error: true
               run : |
                   yarn
                   yarn run test-ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -35,7 +35,6 @@ jobs:
 
             - name: Run UT
               working-directory: ./client
-              continue-on-error: true
               run : |
                   yarn
                   yarn run test-ci

--- a/client/src/actions/deployActions.js
+++ b/client/src/actions/deployActions.js
@@ -93,7 +93,12 @@ export const updateTransferDeployStatus = (publicKey, path, listHash = []) => {
 	return (dispatch) => {
 		const deployStorageValue = getLocalStorageValue(publicKey, path) || [];
 		const updatedValue = deployStorageValue.map((deploy) => {
-			const hashStatus = listHash.find((hash) => hash.hash.toLowerCase() === deploy.deployHash.toLowerCase());
+			if (!deploy.deployHash) {
+				return deploy;
+			}
+			const hashStatus = listHash.find(
+				(item) => item.hash && item.hash.toLowerCase() === deploy.deployHash.toLowerCase(),
+			);
 			return { ...deploy, status: hashStatus ? hashStatus.status : deploy.status };
 		});
 		dispatch(updateTransferDeploysLocalStorage(publicKey, path, updatedValue, 'set'));

--- a/client/src/actions/deployActions.test.js
+++ b/client/src/actions/deployActions.test.js
@@ -91,6 +91,13 @@ describe('updateTransferDeployStatus', () => {
 		expect(getLocalStorageValue).toHaveBeenCalled();
 		expect(mockDispatch).toHaveBeenCalled();
 	});
+	test('Should ignore the deploy do not have deployHash', () => {
+		const mockDispatch = jest.fn();
+		getLocalStorageValue.mockReturnValue([{ deployHash: 'test', status: 'pending' }, { status: 'pending' }]);
+		updateTransferDeployStatus('pbkeytest', 'local.path', [{ hash: 'test' }])(mockDispatch);
+		expect(getLocalStorageValue).toHaveBeenCalled();
+		expect(mockDispatch).toHaveBeenCalled();
+	});
 });
 
 describe('pushTransferToLocalStorage', () => {


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)

- Ignore the deploy do not have deploy hash
- Should stop building if UTs have been failed

### Checklist (If you won't pass this checklist please comment why)

-   [x] I removed all commented or unnecessary code.
-   [ ] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):
