### PR TITLE
UPDATE: - Update UT to make sure Create wallet state is cleared after…

### DIFF
--- a/client/src/components/web-extension/Common/CreatePasswordPage/useCreateUser.test.js
+++ b/client/src/components/web-extension/Common/CreatePasswordPage/useCreateUser.test.js
@@ -4,6 +4,7 @@ import { act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { onBindingAuthInfo } from '@cd/actions/userActions';
 import { createUserServiceSW } from '@cd/components/hooks/useServiceWorker';
+import { resetWalletCreation } from '@cd/actions/createWalletActions';
 import useCreateUser from './useCreateUser';
 
 jest.mock('casper-storage', () => ({
@@ -16,6 +17,10 @@ jest.mock('@cd/actions/userActions', () => ({
 jest.mock('@cd/hooks/useServiceWorker', () => ({
 	...jest.requireActual('@cd/hooks/useServiceWorker'),
 	createUserServiceSW: jest.fn(),
+}));
+jest.mock('@cd/actions/createWalletActions', () => ({
+	...jest.requireActual('@cd/actions/createWalletActions'),
+	resetWalletCreation: jest.fn(),
 }));
 
 describe('useCreateUser', () => {
@@ -86,7 +91,6 @@ describe('useCreateUser', () => {
 				},
 			});
 		});
-
 		expect(onBindingAuthInfo).toHaveBeenCalledTimes(1);
 		expect(onBindingAuthInfo).toHaveBeenCalledWith(
 			{
@@ -97,5 +101,6 @@ describe('useCreateUser', () => {
 			},
 			expect.anything(),
 		);
+		expect(resetWalletCreation).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)
Update UT to make sure `resetWalletCreation` is called on Creating new Wallet successfully

### Checklist (If you won't pass this checklist please comment why)

-   [X] I removed all commented or unnecessary code.
-   [X] Provide the screenshots due to UI changed or bug fixed
-   [X] My code has covered these test cases:
  -  Should call `onBindingAuthInfo` when creating new User successfully
![image](https://user-images.githubusercontent.com/610234/188411080-4d87f66e-b64f-4113-a7f5-ec055075a668.png)
