### PR TITLE
Fix: #154 revert currentStep selector & update logic check pathname

### DIFF
--- a/client/src/components/web-extension/Common/Header/OuterHeader.jsx
+++ b/client/src/components/web-extension/Common/Header/OuterHeader.jsx
@@ -6,6 +6,8 @@ import BackArrow from '@cd/assets/image/back-arrow.svg';
 import './OuterHeader.scss';
 import { selectCreateWalletCurrentStep } from '@cd/selectors/createWallet';
 
+const DISALLOWED_PATH_NAMES = ['/connectAccount'];
+
 export const OuterHeader = ({ setHeader, header }) => {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
@@ -33,6 +35,10 @@ export const OuterHeader = ({ setHeader, header }) => {
 	}, [navigate, dispatch, setHeader]);
 
 	if (!finalLayoutName) {
+		return null;
+	}
+
+	if (DISALLOWED_PATH_NAMES.includes(pathname)){
 		return null;
 	}
 

--- a/client/src/components/web-extension/Common/Header/OuterHeader.jsx
+++ b/client/src/components/web-extension/Common/Header/OuterHeader.jsx
@@ -1,23 +1,25 @@
 import React, { useCallback, useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { resetWalletCreation } from '@cd/actions/createWalletActions';
 import BackArrow from '@cd/assets/image/back-arrow.svg';
 import './OuterHeader.scss';
+import { selectCreateWalletCurrentStep } from '@cd/selectors/createWallet';
 
 export const OuterHeader = ({ setHeader, header }) => {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
+	const currentStep = useSelector(selectCreateWalletCurrentStep);
 	const { pathname, state } = useLocation();
-	const shouldShowBackArrow = pathname !== '/welcomeBack' && (pathname === '/createWallet' && currentStep !== 0);
+	const shouldShowBackArrow = pathname !== '/welcomeBack' && (pathname !== '/createWallet' || pathname === '/createWallet' && currentStep !== 0);
 
 	const finalLayoutName = useMemo(() => {
-		if (!state?.name) {
-			return undefined;
-		}
-
 		if (header && header !== '') {
 			return header;
+		}
+
+		if (!state?.name) {
+			return undefined;
 		}
 
 		return state?.name;


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)
Root cause:
- Commit which "Remove selector" in other PR make an error on this feature
- Update logic check pathname to avoid "Hide back button" on "Import Phrase"

<img width="876" alt="image" src="https://user-images.githubusercontent.com/20489407/194915195-b77945c1-3222-4c8e-a929-c23f44e4c5ff.png">

<img width="355" alt="image" src="https://user-images.githubusercontent.com/20489407/194915226-077cab0c-df3f-4778-a44e-f2469d8ce8e5.png">


### Checklist (If you won't pass this checklist please comment why)

-   [x] I removed all commented or unnecessary code.
-   [x] Provide the screenshots due to UI changed or bug fixed
-   [x] My code has covered these test cases (please list down your tested cases):
