### PR TITLE
Fix: Wrong account index after re-login again

### DIFF
--- a/client/src/components/hooks/useServiceWorker.js
+++ b/client/src/components/hooks/useServiceWorker.js
@@ -69,6 +69,10 @@ const isUserExist = async () => {
 	return sentMessage({ methodName: 'accountManager.isUserExist' });
 };
 
+const getCurrentIndexByPublicKey = async (publicKey) => {
+	return sentMessage({ methodName: 'accountManager.getCurrentIndexByPublicKey',  params: { publicKey } });
+};
+
 /**
  *
  * Signing Deploy actions
@@ -90,4 +94,5 @@ export {
 	addWalletAccount,
 	setDefaultWallet,
 	isUserExist,
+	getCurrentIndexByPublicKey
 };

--- a/client/src/components/web-extension/Common/Account/AccountManagerModal.jsx
+++ b/client/src/components/web-extension/Common/Account/AccountManagerModal.jsx
@@ -15,11 +15,11 @@ import { formatAccountName } from '@cd/helpers/format';
 import CloseIcon from '@cd/assets/image/close-icon.svg';
 import PlusIcon from '@cd/assets/image/plus-icon.svg';
 import './AccountManagerModal.scss';
-import { getAccountIndex } from '@cd/selectors/user';
+import { getPublicKey } from '@cd/selectors/user';
 
 export const AccountManagerModal = ({ isOpen, onClose, ...restProps }) => {
 	const dispatch = useDispatch();
-	const accountIndex = useSelector(getAccountIndex);
+	const accountIndex = useSelector(getPublicKey);
 
 	const [wallets, loadWallets, isLoading] = useGetWallets();
 
@@ -60,7 +60,7 @@ export const AccountManagerModal = ({ isOpen, onClose, ...restProps }) => {
 						<li
 							key={`wallet-${index}`}
 							className={
-								clsx('cd_we_accounts-modal__list-item', { selected: index === accountIndex})
+								clsx('cd_we_accounts-modal__list-item', { selected: wallet.publicKey === accountIndex})
 							}
 							onClick={() => handleOnSelectWallet(index)}
 						>

--- a/client/src/components/web-extension/Common/Account/index.jsx
+++ b/client/src/components/web-extension/Common/Account/index.jsx
@@ -1,21 +1,25 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { getPublicKey, getAccountTotalBalanceInFiat, getAccountName } from '@cd/selectors/user';
+import { getPublicKey, getAccountTotalBalanceInFiat } from '@cd/selectors/user';
 import { MiddleTruncatedText } from '@cd/components/Common/MiddleTruncatedText';
-import { toFormattedCurrency } from '@cd/helpers/format';
+import { formatAccountName, toFormattedCurrency } from '@cd/helpers/format';
 import ServiceWorkerRequired from '@cd/hocs/ServiceWorkerRequired';
 import Copy from '@cd/components/Common/Button/Copy';
 import EditIcon from '@cd/assets/image/edit-icon.svg';
+import { getCurrentIndexByPublicKey } from '@cd/components/hooks/useServiceWorker';
 import { AccountManagerModal } from './AccountManagerModal';
-
 import './index.scss';
 
 export const AccountInfo = () => {
+	const [accountName, setAccountName] = useState('Account 1');
 	const [isOpenAccountModal, setIsOpenAccountModal] = useState(false);
 	//Selectors
 	const publicKey = useSelector(getPublicKey);
-	const accountName = useSelector(getAccountName);
 	const totalFiatBalance = useSelector(getAccountTotalBalanceInFiat);
+
+	useEffect(() => {
+		getCurrentIndexByPublicKey(publicKey).then((index = 0) => setAccountName(formatAccountName(index)));
+	},[publicKey]);
 
 	const handleOnCloseAccountModal = () => {
 		setIsOpenAccountModal(false);
@@ -30,7 +34,7 @@ export const AccountInfo = () => {
 			<div className="cd_we_account_info">
 				<div className="cd_we_account_name" onClick={handleOnOpenAccountModal}>
 					<span>
-						{accountName ?? 'Account 1'}
+						{accountName}
 					</span>
 					<EditIcon />
 				</div>

--- a/client/src/components/web-extension/Common/Account/index.test.jsx
+++ b/client/src/components/web-extension/Common/Account/index.test.jsx
@@ -3,6 +3,13 @@ import * as redux from 'react-redux';
 import { render, cleanup } from '@testing-library/react';
 import { AccountInfo } from './index';
 
+
+jest.mock('@cd/components/hooks/useServiceWorker', () => {
+	return {
+		getCurrentIndexByPublicKey: jest.fn(() => Promise.resolve(0)),
+	};
+});
+
 afterEach(cleanup);
 let spyOnUseSelector;
 beforeEach(() => {
@@ -11,7 +18,7 @@ beforeEach(() => {
 });
 
 test('Should display account info', () => {
-	spyOnUseSelector.mockReturnValue([]).mockReturnValueOnce('test').mockReturnValueOnce('Account 1').mockReturnValueOnce(10);
+	spyOnUseSelector.mockReturnValue([]).mockReturnValueOnce('test').mockReturnValueOnce(10);
 
 	const { getByText } = render(<AccountInfo />);
 	expect(getByText('Account 1').textContent).toBe('Account 1');

--- a/client/src/services/ServiceWorker/Controllers/AccountController.js
+++ b/client/src/services/ServiceWorker/Controllers/AccountController.js
@@ -102,6 +102,10 @@ class AccountController {
 		return hdWallets;
 	};
 
+	getCurrentIndexByPublicKey = async ({ publicKey }) => {
+		return this.userService.getCurrentIndexByPublicKey(publicKey);
+	}
+
 	addWalletAccount = async ({ index, description }) => {
 		return this.userService.addWalletAccount(index, description);
 	};

--- a/client/src/services/ServiceWorker/serviceWorker.js
+++ b/client/src/services/ServiceWorker/serviceWorker.js
@@ -72,4 +72,5 @@ async function setupPopupServices() {
 	rpc.register('accountManager.setDefaultWallet', accountController.setDefaultWallet);
 	rpc.register('accountManager.clearUser', accountController.clearUser);
 	rpc.register('accountManager.isUserExist', accountController.isUserExist);
+	rpc.register('accountManager.getCurrentIndexByPublicKey', accountController.getCurrentIndexByPublicKey);
 }

--- a/client/src/services/UserService.js
+++ b/client/src/services/UserService.js
@@ -160,6 +160,13 @@ export class UserService {
 		})));
 	}
 
+	getCurrentIndexByPublicKey = async (publicKey) => {
+		const wallets = await this.getHDWallets();
+		const foundIndex = wallets.findIndex((wallet) => wallet.publicKey === publicKey);
+
+		return Math.max(foundIndex, 0);
+	}
+
 	addWalletAccount = async (index, description) => {
 		const user = this.instance;
 


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)

Reproduce step:
1. Create 10 accounts
2. Select the second account (Account 2)
3. Lock wallet and re-login

- Actually: Wallet shows Account 2 and the balance of Account 1
- Expected: Wallet show Account 1 and balance of Account 1


Solution:
- Using public key to find index of account

### Checklist (If you won't pass this checklist please comment why)

-   [x] I removed all commented or unnecessary code.
-   [x] Provide the screenshots due to UI changed or bug fixed
-   [x] My code has covered these test cases (please list down your tested cases):
