### PR TITLE
UPDATE: - Fix up error when calling setPublicKey from browser

### DIFF
--- a/client/src/actions/userActions.js
+++ b/client/src/actions/userActions.js
@@ -58,8 +58,14 @@ export const setPublicKeyToStore = (publicKey, loginOptions = {}) => {
  */
 export const setPublicKey = (publicKey, loginOptions = {}) => {
 	return async (dispatch) => {
-		// need to get from storage here to prevent missing user info
-		const { loginOptions: cachedLoginOptions } = await getConnectedAccountChromeLocalStorage();
+		let cachedLoginOptions = {};
+		if (isUsingExtension()) {
+			// need to get from storage here to prevent missing user info
+			const { loginOptions } = await getConnectedAccountChromeLocalStorage();
+			cachedLoginOptions = {
+				...loginOptions
+			}
+		}
 		//Cache public key and login options
 		await cacheLoginInfoToLocalStorage(publicKey, { ...loginOptions, ...cachedLoginOptions });
 		dispatch(setPublicKeyToStore(publicKey, loginOptions));


### PR DESCRIPTION
**Describe the bug**
This bug prevent user from logging into CasperDash dashboard in browser.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to http://localhost:3000/dashboard
2. Try to login to CasperSigner and use one of your account
3. Check devtool and see error log

![image](https://user-images.githubusercontent.com/610234/209793336-055ef891-89e7-4aab-a155-caeaa1163a40.png)


**Expected behavior**
It should be success when User connects via Casper Signer


**Additional context**
Add any other context about the problem here.

