### PR TITLE
Refactor: HAL-02 Display secret keys with HTML5 Canvas

### DIFF
--- a/client/src/components/web-extension/Common/CanvasText/index.jsx
+++ b/client/src/components/web-extension/Common/CanvasText/index.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+const CanvasText = ({text, width, height}) => {
+    const canvasRef = useRef();
+
+    const writeText = (info, style = {}) => {
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext("2d");
+        const { text, x, y } = info;
+        const { fontSize = 14, fontFamily = 'Arial', color = 'black', textAlign = 'left', textBaseline = 'top' } = style;
+     
+        ctx.beginPath();
+        ctx.font = fontSize + 'px ' + fontFamily;
+        ctx.textAlign = textAlign;
+        ctx.textBaseline = textBaseline;
+        ctx.fillStyle = color;
+        ctx.fillText(text, x, y);
+        ctx.stroke();
+        ctx.save();
+    }
+
+    useEffect(() => {
+        writeText({ text, x: 4, y: 0 });
+    }, [text]); 
+
+    return (
+        <canvas
+	ref={canvasRef} 
+	width={width}
+	height={height}
+        />
+    )
+}
+
+CanvasText.propTypes = {
+	text: PropTypes.string,
+	width: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]),
+	height: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]),
+};
+
+export default CanvasText;

--- a/client/src/components/web-extension/CreateWallet/RecoveryPhrasePage.jsx
+++ b/client/src/components/web-extension/CreateWallet/RecoveryPhrasePage.jsx
@@ -10,6 +10,7 @@ import CopyButton from '@cd/web-extension/Common/CopyButton';
 import { selectCreateWalletKeyphraseAsMap, selectCreateWalletKeyphrase } from '@cd/selectors/createWallet';
 import { NUMBER_OF_RECOVERY_WORDS } from '@cd/constants/key';
 import { ONE_MINUTE } from '@cd/constants/time';
+import CanvasText from '@cd/web-extension/Common/CanvasText/index';
 
 import './RecoveryPhrasePage.scss';
 
@@ -57,16 +58,14 @@ const RecoveryPhrasePage = () => {
 				<ul className="cd_we_create-keyphrase--column">
 					{leftKeys?.map((word, index) => (
 						<li className="cd_we_keyphrase--word" key={`left-${word}`}>
-							<span className="counter">{index + 1}</span>
-							<span className="value">{word}</span>
+							<CanvasText text={`${index + 1}. ${word}`} width="80" height="22" />
 						</li>
 					))}
 				</ul>
 				<ul className="cd_we_create-keyphrase--column">
 					{rightKeys?.map((word, index) => (
 						<li className="cd_we_keyphrase--word" key={`right-${word}`}>
-							<span className="counter">{index + (1 + TOTAL_KEYWORDS / 2)}</span>
-							<span className="value">{word}</span>
+							<CanvasText text={`${index + (1 + TOTAL_KEYWORDS / 2)}. ${word}`} width="80" height="22" />
 						</li>
 					))}
 				</ul>

--- a/client/src/components/web-extension/RecoveryPhrase/RecoveryPhrase.scss
+++ b/client/src/components/web-extension/RecoveryPhrase/RecoveryPhrase.scss
@@ -47,9 +47,10 @@
 		flex-direction: column;
 		flex-wrap: wrap;
 		flex: 0 0 auto;
-		height: 270px;
+		height: 290px;
 		overflow: auto;
 		justify-content: space-between;
+		align-items: center;
 		list-style: none;
 		width: 100%;
 		padding: 0;

--- a/client/src/components/web-extension/RecoveryPhrase/index.jsx
+++ b/client/src/components/web-extension/RecoveryPhrase/index.jsx
@@ -52,7 +52,6 @@ const RecoveryPhrase = () => {
 					>
 						{words?.map((word, index) => (
 							<li className="cd_we_recovery-keyphrase__word" key={`left-${index}`}>
-								{/* <span className="value">{word}</span> */}
 								<CanvasText text={`${index + 1}. ${word}`} width="80" height="22" />
 							</li>
 						))}

--- a/client/src/components/web-extension/RecoveryPhrase/index.jsx
+++ b/client/src/components/web-extension/RecoveryPhrase/index.jsx
@@ -6,6 +6,7 @@ import EnterPasswordModal from '@cd/web-extension/Common/LoginModal/EnterPasswor
 import { getKeyphrase } from '@cd/components/hooks/useServiceWorker';
 import CopyButton from '@cd/web-extension/Common/CopyButton';
 import { ONE_MINUTE } from '@cd/constants/time';
+import CanvasText from '@cd/web-extension/Common/CanvasText/index';
 
 import './RecoveryPhrase.scss';
 
@@ -51,8 +52,8 @@ const RecoveryPhrase = () => {
 					>
 						{words?.map((word, index) => (
 							<li className="cd_we_recovery-keyphrase__word" key={`left-${index}`}>
-								<span className="counter">{index + 1}</span>
-								<span className="value">{word}</span>
+								{/* <span className="value">{word}</span> */}
+								<CanvasText text={`${index + 1}. ${word}`} width="80" height="22" />
 							</li>
 						))}
 					</ul>


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)
- Display recovery keys with HTML5 Canvas when:
     1. User view recovery keys
     2. User create new wallet and generate recovery keys

<img width="804" alt="image" src="https://github.com/CasperDash/casperdash-client/assets/20489407/d4882c90-cbbf-4248-b6c8-8431e5ea0382">

### Checklist (If you won't pass this checklist please comment why)

-   [x] I removed all commented or unnecessary code.
-   [ ] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):
