### PR TITLE
Fix: Background color UI for confirm delete modal

### DIFF
--- a/client/src/components/web-extension/Common/DeleteAllDataLinkConfirm/ConfirmDeleteAllDataModal.scss
+++ b/client/src/components/web-extension/Common/DeleteAllDataLinkConfirm/ConfirmDeleteAllDataModal.scss
@@ -17,6 +17,10 @@
 		display: flex;
 	}
 
+	.modal-content {
+		background-color: var(--component-background);
+	}
+
 	&--word {
 		font-weight: bold;
 	}


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)

<img width="352" alt="image" src="https://github.com/CasperDash/casperdash-client/assets/20489407/7c43f602-81a5-4f5d-b6ab-c161ada20c7e">

### Checklist (If you won't pass this checklist please comment why)

-   [ ] I removed all commented or unnecessary code.
-   [x] Provide the screenshots due to UI changed or bug fixed
-   [ ] My code has covered these test cases (please list down your tested cases):
